### PR TITLE
Use lizmapProxy::getRemoteData instead of curl directly

### DIFF
--- a/occtax/controllers/lizmapService.classic.php
+++ b/occtax/controllers/lizmapService.classic.php
@@ -432,16 +432,7 @@ class lizmapServiceCtrl extends serviceCtrl {
     $querystring = $url . implode('&', $data);
 
     // Get data form server
-    $ch = curl_init();
-    curl_setopt($ch, CURLOPT_HEADER, 0);
-    curl_setopt($ch, CURLOPT_URL, $querystring);
-    curl_setopt( $ch, CURLOPT_SSL_VERIFYPEER, false );
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-    $data = curl_exec($ch);
-    $info = curl_getinfo($ch);
-    $mime = $info['content_type'];
-    curl_close($ch);
+    list($data, $mime, $code) = lizmapProxy::getRemoteData($querystring);
 
     // Delete temp file
     unlink($tempProjectPath);


### PR DESCRIPTION
Using getRemoteData is better, as it take care of many things like some configuration parameters (proxy, api to use etc..)

